### PR TITLE
updating sources problem with spectool

### DIFF
--- a/ca-certificates.spec
+++ b/ca-certificates.spec
@@ -42,31 +42,31 @@ License: MIT AND GPLv2+
 URL: https://fedoraproject.org/wiki/CA-Certificates
 
 #Please always update both certdata.txt and nssckbi.h
-Source0: certdata.txt
-Source1: nssckbi.h
-Source2: update-ca-trust
-Source3: trust-fixes
-Source4: certdata2pem.py
-Source5: ca-legacy.conf
-Source6: ca-legacy
-Source9: ca-legacy.8.txt
-Source10: update-ca-trust.8.txt
-Source11: README.usr
-Source12: README.etc
-Source13: README.extr
-Source14: README.java
-Source15: README.openssl
-Source16: README.pem
-Source17: README.edk2
-Source18: README.src
-Source19: README.etcssl
-Source30: fetch.sh
-Source31: README
-Source32: sources
-Source33: sort-blocks.py
-Source34: check_certs.sh
-Source35: fetch_objsign.sh
-Source36: mergepem2certdata.py
+Source0: https://github.com/sailfishos/ca-certificates/raw/master/certdata.txt
+Source1: https://github.com/sailfishos/ca-certificates/raw/master/nssckbi.h
+Source2: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust
+Source3: https://github.com/sailfishos/ca-certificates/raw/master/trust-fixes
+Source4: https://github.com/sailfishos/ca-certificates/raw/master/certdata2pem.py
+Source5: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.conf
+Source6: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy
+Source9: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.8.txt
+Source10: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust.8.txt
+Source11: https://github.com/sailfishos/ca-certificates/raw/master/README.usr
+Source12: https://github.com/sailfishos/ca-certificates/raw/master/README.etc
+Source13: https://github.com/sailfishos/ca-certificates/raw/master/README.extr
+Source14: https://github.com/sailfishos/ca-certificates/raw/master/README.java
+Source15: https://github.com/sailfishos/ca-certificates/raw/master/README.openssl
+Source16: https://github.com/sailfishos/ca-certificates/raw/master/README.pem
+Source17: https://github.com/sailfishos/ca-certificates/raw/master/README.edk2
+Source18: https://github.com/sailfishos/ca-certificates/raw/master/README.src
+Source19: https://github.com/sailfishos/ca-certificates/raw/master/README.etcssl
+Source30: https://github.com/sailfishos/ca-certificates/raw/master/fetch.sh
+Source31: https://github.com/sailfishos/ca-certificates/raw/master/README
+Source32: https://github.com/sailfishos/ca-certificates/raw/master/sources
+Source33: https://github.com/sailfishos/ca-certificates/raw/master/sort-blocks.py
+Source34: https://github.com/sailfishos/ca-certificates/raw/master/check_certs.sh
+Source35: https://github.com/sailfishos/ca-certificates/raw/master/fetch_objsign.sh
+Source36: https://github.com/sailfishos/ca-certificates/raw/master/mergepem2certdata.py
 
 BuildArch: noarch
 

--- a/ca-certificates.spec
+++ b/ca-certificates.spec
@@ -82,7 +82,7 @@ Requires(post): p11-kit-trust >= 0.23
 Requires: p11-kit >= 0.23
 Requires: p11-kit-trust >= 0.23
 
-BuildRequires: perl-interpreter
+#BuildRequires: perl-interpreter
 BuildRequires: python3
 BuildRequires: openssl
 #BuildRequires: asciidoc

--- a/ca-certificates.spec
+++ b/ca-certificates.spec
@@ -82,8 +82,8 @@ Requires(post): p11-kit-trust >= 0.23
 Requires: p11-kit >= 0.23
 Requires: p11-kit-trust >= 0.23
 
-#BuildRequires: perl-interpreter
-BuildRequires: python3-base
+BuildRequires: perl-interpreter
+BuildRequires: python3
 BuildRequires: openssl
 #BuildRequires: asciidoc
 #BuildRequires: xmlto


### PR DESCRIPTION
updating sources problem with spectool

with your version build srpms with rpmbuild and spectool

`wget "https://github.com/sailfishos/ca-certificates/raw/master/ca-certificates.spec" -qO "$HOME/rpmbuild/SPECS/ca-certificates.spec" && LANG=en spectool -g -R $HOME/rpmbuild/SPECS/ca-certificates.spec && LANG=en rpmbuild -bs $HOME/rpmbuild/SPECS/ca-certificates.spec`

error


```
warning: source_date_epoch_from_changelog set but %changelog is missing
error: Bad file: $HOME/rpmbuild/SOURCES/mergepem2certdata.py: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/fetch_objsign.sh: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/check_certs.sh: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/sort-blocks.py: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/sources: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/fetch.sh: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.etcssl: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.src: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.edk2: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.pem: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.openssl: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.java: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.extr: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.etc: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/README.usr: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/update-ca-trust.8.txt: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/ca-legacy.8.txt: No such file or directory
error: Bad file:$HOME/rpmbuild/SOURCES/ca-legacy: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/ca-legacy.conf: No such file or directory
error: Bad file:$HOME/rpmbuild/SOURCES/certdata2pem.py: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/trust-fixes: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/update-ca-trust: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/nssckbi.h: No such file or directory
error: Bad file: $HOME/rpmbuild/SOURCES/certdata.txt: No such file or directory

RPM build warnings:
    source_date_epoch_from_changelog set but %changelog is missing

RPM build errors:
    Bad file: $HOME/rpmbuild/SOURCES/mergepem2certdata.py: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/fetch_objsign.sh: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/check_certs.sh: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/sort-blocks.py: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/sources: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/fetch.sh: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.etcssl: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.src: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.edk2: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.pem: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.openssl: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.java: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.extr: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.etc: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/README.usr: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/update-ca-trust.8.txt: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/ca-legacy.8.txt: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/ca-legacy: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/ca-legacy.conf: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/certdata2pem.py: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/trust-fixes: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/update-ca-trust: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/nssckbi.h: No such file or directory
    Bad file: $HOME/rpmbuild/SOURCES/certdata.txt: No such file or directory
```

with your version build srpms with mock and spectool

`wget "https://github.com/sailfishos/ca-certificates/raw/master/ca-certificates.spec" -qO "$HOME/rpmbuild/SPECS/ca-certificates.spec" && LANG=en spectool -g -R $HOME/rpmbuild/SPECS/ca-certificates.spec && LANG=en mock -r fedora-39-x86_64 --buildsrpm --spec $HOME/rpmbuild/SPECS/ca-certificates.spec --sources $HOME/rpmbuild/SOURCES/`

error


```
INFO: mock.py version 5.4 starting (python version = 3.12.1, NVR = mock-5.4-1.fc39), args: /usr/libexec/mock/mock -r fedora-39-x86_64 --buildsrpm --spec $HOME/rpmbuild/SPECS/ca-certificates.spec --sources $HOME/rpmbuild/SOURCES/
Start(bootstrap): init plugins
INFO: selinux disabled
Finish(bootstrap): init plugins
Start: init plugins
INFO: selinux disabled
Finish: init plugins
INFO: Signal handler active
Start: run
INFO: Start($ḦOME/rpmbuild/SPECS/ca-certificates.spec)  Config(fedora-39-x86_64)
Start: clean chroot
Finish: clean chroot
Mock Version: 5.4
INFO: Mock Version: 5.4
Start(bootstrap): chroot init
INFO: calling preinit hooks
INFO: enabled root cache
INFO: enabled package manager cache
Start(bootstrap): cleaning package manager metadata
Finish(bootstrap): cleaning package manager metadata
INFO: Package manager dnf detected and used (fallback)
Finish(bootstrap): chroot init
Start: chroot init
INFO: calling preinit hooks
INFO: enabled root cache
Start: unpacking root cache
Finish: unpacking root cache
INFO: enabled package manager cache
Start: cleaning package manager metadata
Finish: cleaning package manager metadata
INFO: enabled HW Info plugin
INFO: Package manager dnf detected and used (direct choice)
INFO: Buildroot is handled by package management downloaded with a bootstrap image:
  rpm-4.19.0-1.fc39.x86_64
  rpm-sequoia-1.5.0-1.fc39.x86_64
  python3-dnf-4.18.2-1.fc39.noarch
  python3-dnf-plugins-core-4.4.4-1.fc39.noarch
  yum-4.18.2-1.fc39.noarch
Start: dnf update
No matches found for the following disable plugin patterns: local, spacewalk, versionlock
fedora                                                                                                                                                        168 kB/s |  24 kB     00:00    
updates                                                                                                                                                       158 kB/s |  17 kB     00:00    
updates                                                                                                                                                       945 kB/s | 505 kB     00:00    
Last metadata expiration check: 0:00:01 ago on Wed Feb 14 11:38:19 2024.
Dependencies resolved.
Nothing to do.
Complete!
Finish: dnf update
Finish: chroot init
Start: buildsrpm
Start: rpmbuild -bs
warning: source_date_epoch_from_changelog set but %changelog is missing
error: Bad file: /builddir/build/SOURCES/mergepem2certdata.py: No such file or directory
error: Bad file: /builddir/build/SOURCES/fetch_objsign.sh: No such file or directory
error: Bad file: /builddir/build/SOURCES/check_certs.sh: No such file or directory
error: Bad file: /builddir/build/SOURCES/sort-blocks.py: No such file or directory
error: Bad file: /builddir/build/SOURCES/sources: No such file or directory
error: Bad file: /builddir/build/SOURCES/README: No such file or directory
error: Bad file: /builddir/build/SOURCES/fetch.sh: No such file or directory
Building target platforms: x86_64
Building for target x86_64

RPM build warnings:

RPM build errors:
error: Bad file: /builddir/build/SOURCES/README.etcssl: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.src: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.edk2: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.pem: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.openssl: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.java: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.extr: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.etc: No such file or directory
error: Bad file: /builddir/build/SOURCES/README.usr: No such file or directory
error: Bad file: /builddir/build/SOURCES/update-ca-trust.8.txt: No such file or directory
error: Bad file: /builddir/build/SOURCES/ca-legacy.8.txt: No such file or directory
error: Bad file: /builddir/build/SOURCES/ca-legacy: No such file or directory
error: Bad file: /builddir/build/SOURCES/ca-legacy.conf: No such file or directory
error: Bad file: /builddir/build/SOURCES/certdata2pem.py: No such file or directory
error: Bad file: /builddir/build/SOURCES/trust-fixes: No such file or directory
error: Bad file: /builddir/build/SOURCES/update-ca-trust: No such file or directory
error: Bad file: /builddir/build/SOURCES/nssckbi.h: No such file or directory
error: Bad file: /builddir/build/SOURCES/certdata.txt: No such file or directory
    source_date_epoch_from_changelog set but %changelog is missing
    Bad file: /builddir/build/SOURCES/mergepem2certdata.py: No such file or directory
    Bad file: /builddir/build/SOURCES/fetch_objsign.sh: No such file or directory
    Bad file: /builddir/build/SOURCES/check_certs.sh: No such file or directory
    Bad file: /builddir/build/SOURCES/sort-blocks.py: No such file or directory
    Bad file: /builddir/build/SOURCES/sources: No such file or directory
    Bad file: /builddir/build/SOURCES/README: No such file or directory
    Bad file: /builddir/build/SOURCES/fetch.sh: No such file or directory
    Bad file: /builddir/build/SOURCES/README.etcssl: No such file or directory
    Bad file: /builddir/build/SOURCES/README.src: No such file or directory
    Bad file: /builddir/build/SOURCES/README.edk2: No such file or directory
    Bad file: /builddir/build/SOURCES/README.pem: No such file or directory
    Bad file: /builddir/build/SOURCES/README.openssl: No such file or directory
    Bad file: /builddir/build/SOURCES/README.java: No such file or directory
    Bad file: /builddir/build/SOURCES/README.extr: No such file or directory
    Bad file: /builddir/build/SOURCES/README.etc: No such file or directory
    Bad file: /builddir/build/SOURCES/README.usr: No such file or directory
    Bad file: /builddir/build/SOURCES/update-ca-trust.8.txt: No such file or directory
    Bad file: /builddir/build/SOURCES/ca-legacy.8.txt: No such file or directory
    Bad file: /builddir/build/SOURCES/ca-legacy: No such file or directory
    Bad file: /builddir/build/SOURCES/ca-legacy.conf: No such file or directory
    Bad file: /builddir/build/SOURCES/certdata2pem.py: No such file or directory
    Bad file: /builddir/build/SOURCES/trust-fixes: No such file or directory
    Bad file: /builddir/build/SOURCES/update-ca-trust: No such file or directory
    Bad file: /builddir/build/SOURCES/nssckbi.h: No such file or directory
    Bad file: /builddir/build/SOURCES/certdata.txt: No such file or directory
Finish: rpmbuild -bs
Finish: buildsrpm
ERROR: Exception($HOME/rpmbuild/SPECS/ca-certificates.spec) Config(fedora-39-x86_64) 0 minutes 12 seconds
INFO: Results and/or logs in: /var/lib/mock/fedora-39-x86_64/result
ERROR: Command failed: 
 # /usr/bin/systemd-nspawn -q -M 30d5c4933e8b486a9fe17936ab3bb46a -D /var/lib/mock/fedora-39-x86_64/root -a -u mockbuild --capability=cap_ipc_lock --bind=/tmp/mock-resolv.0nj66f11:/etc/resolv.conf --bind=/dev/btrfs-control --bind=/dev/mapper/control --bind=/dev/fuse --bind=/dev/loop-control --bind=/dev/loop0 --bind=/dev/loop1 --bind=/dev/loop2 --bind=/dev/loop3 --bind=/dev/loop4 --bind=/dev/loop5 --bind=/dev/loop6 --bind=/dev/loop7 --bind=/dev/loop8 --bind=/dev/loop9 --bind=/dev/loop10 --bind=/dev/loop11 --console=pipe --setenv=TERM=vt100 --setenv=SHELL=/bin/bash --setenv=HOME=/builddir --setenv=HOSTNAME=mock --setenv=PATH=/usr/bin:/bin:/usr/sbin:/sbin '--setenv=PROMPT_COMMAND=printf "\033]0;<mock-chroot>\007"' '--setenv=PS1=<mock-chroot> \s-\v\$ ' --setenv=LANG=C.UTF-8 --resolv-conf=off bash --login -c '/usr/bin/rpmbuild -bs --noclean --target x86_64 --nodeps /builddir/build/SPECS/ca-certificates.spec'
```

with this update build srpms with rpmbuild and spectool

`wget "https://github.com/andykimpe/ca-certificates/raw/master/ca-certificates.spec" -qO "$HOME/rpmbuild/SPECS/ca-certificates.spec" && LANG=en spectool -g -R $HOME/rpmbuild/SPECS/ca-certificates.spec && LANG=en rpmbuild -bs $HOME/rpmbuild/SPECS/ca-certificates.spec`


work


```
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/certdata.txt
100% of   3.0 MiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: certdata.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/nssckbi.h
100% of   2.4 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: nssckbi.h
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust
100% of   3.7 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: update-ca-trust
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/trust-fixes
100% of   1.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: trust-fixes
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/certdata2pem.py
100% of  16.2 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: certdata2pem.py
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.conf
100% of 980.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy.conf
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy
100% of   1.6 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.8.txt
100% of   2.8 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy.8.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust.8.txt
100% of  12.9 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: update-ca-trust.8.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.usr
100% of 937.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.usr
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.etc
100% of 166.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.etc
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.extr
100% of 560.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.extr
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.java
100% of 726.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.java
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.openssl
100% of 787.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.openssl
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.pem
100% of 898.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.pem
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.edk2
100% of 566.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.edk2
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.src
100% of 932.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.src
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.etcssl
100% of   1.1 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.etcssl
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/fetch.sh
100% of   5.4 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: fetch.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README
100% of 292.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/sources
|   0.0 B Elapsed Time: 0:00:00                                                                                                                                                              
Downloaded: sources
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/sort-blocks.py
100% of 828.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: sort-blocks.py
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/check_certs.sh
100% of   2.1 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: check_certs.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/fetch_objsign.sh
100% of   2.6 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: fetch_objsign.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/mergepem2certdata.py
100% of  15.0 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: mergepem2certdata.py
warning: source_date_epoch_from_changelog set but %changelog is missing
Wrote: $HOME/rpmbuild/SRPMS/ca-certificates-2023.2.62_v7.0.401-6.src.rpm

RPM build warnings:
    source_date_epoch_from_changelog set but %changelog is missing
```




with your version build srpms with mock and spectool

`rm -rf $HOME/rpmbuild/SOURCES/* && wget "https://github.com/andykimpe/ca-certificates/raw/master/ca-certificates.spec" -qO "$HOME/rpmbuild/SPECS/ca-certificates.spec" && LANG=en spectool -g -R $HOME/rpmbuild/SPECS/ca-certificates.spec && LANG=en mock -r fedora-39-x86_64 --buildsrpm --spec $HOME/rpmbuild/SPECS/ca-certificates.spec --sources $HOME/rpmbuild/SOURCES/`



work



```
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/certdata.txt
100% of   3.0 MiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: certdata.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/nssckbi.h
100% of   2.4 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: nssckbi.h
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust
100% of   3.7 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: update-ca-trust
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/trust-fixes
100% of   1.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: trust-fixes
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/certdata2pem.py
100% of  16.2 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: certdata2pem.py
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.conf
100% of 980.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy.conf
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy
100% of   1.6 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/ca-legacy.8.txt
100% of   2.8 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: ca-legacy.8.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/update-ca-trust.8.txt
100% of  12.9 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: update-ca-trust.8.txt
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.usr
100% of 937.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.usr
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.etc
100% of 166.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.etc
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.extr
100% of 560.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.extr
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.java
100% of 726.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.java
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.openssl
100% of 787.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.openssl
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.pem
100% of 898.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.pem
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.edk2
100% of 566.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.edk2
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.src
100% of 932.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.src
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README.etcssl
100% of   1.1 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README.etcssl
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/fetch.sh
100% of   5.4 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: fetch.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/README
100% of 292.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: README
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/sources
|   0.0 B Elapsed Time: 0:00:00                                                                                                                                                              
Downloaded: sources
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/sort-blocks.py
100% of 828.0 B |######################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: sort-blocks.py
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/check_certs.sh
100% of   2.1 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: check_certs.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/fetch_objsign.sh
100% of   2.6 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: fetch_objsign.sh
Downloading: https://github.com/sailfishos/ca-certificates/raw/master/mergepem2certdata.py
100% of  15.0 KiB |####################################################################################################################################| Elapsed Time: 0:00:00 Time:  0:00:00
Downloaded: mergepem2certdata.py
INFO: mock.py version 5.4 starting (python version = 3.12.1, NVR = mock-5.4-1.fc39), args: /usr/libexec/mock/mock -r fedora-39-x86_64 --buildsrpm --spec $HOME/rpmbuild/SPECS/ca-certificates.spec --sources $HOME/rpmbuild/SOURCES/
Start(bootstrap): init plugins
INFO: selinux disabled
Finish(bootstrap): init plugins
Start: init plugins
INFO: selinux disabled
Finish: init plugins
INFO: Signal handler active
Start: run
INFO: Start($HOME/rpmbuild/SPECS/ca-certificates.spec)  Config(fedora-39-x86_64)
Start: clean chroot
Finish: clean chroot
Mock Version: 5.4
INFO: Mock Version: 5.4
Start(bootstrap): chroot init
INFO: calling preinit hooks
INFO: enabled root cache
INFO: enabled package manager cache
Start(bootstrap): cleaning package manager metadata
Finish(bootstrap): cleaning package manager metadata
INFO: Package manager dnf detected and used (fallback)
Finish(bootstrap): chroot init
Start: chroot init
INFO: calling preinit hooks
INFO: enabled root cache
Start: unpacking root cache
Finish: unpacking root cache
INFO: enabled package manager cache
Start: cleaning package manager metadata
Finish: cleaning package manager metadata
INFO: enabled HW Info plugin
INFO: Package manager dnf detected and used (direct choice)
INFO: Buildroot is handled by package management downloaded with a bootstrap image:
  rpm-4.19.0-1.fc39.x86_64
  rpm-sequoia-1.5.0-1.fc39.x86_64
  python3-dnf-4.18.2-1.fc39.noarch
  python3-dnf-plugins-core-4.4.4-1.fc39.noarch
  yum-4.18.2-1.fc39.noarch
Start: dnf update
No matches found for the following disable plugin patterns: local, spacewalk, versionlock
fedora                                                                                                                                                        139 kB/s |  24 kB     00:00    
updates                                                                                                                                                       164 kB/s |  17 kB     00:00    
updates                                                                                                                                                       1.8 MB/s | 2.4 MB     00:01    
Dependencies resolved.
Nothing to do.
Complete!
Finish: dnf update
Finish: chroot init
Start: buildsrpm
Start: rpmbuild -bs
warning: source_date_epoch_from_changelog set but %changelog is missing
Building target platforms: x86_64
Building for target x86_64
Wrote: /builddir/build/SRPMS/ca-certificates-2023.2.62_v7.0.401-6.src.rpm

RPM build warnings:
    source_date_epoch_from_changelog set but %changelog is missing
Finish: rpmbuild -bs
Finish: buildsrpm
INFO: Done($HOME/rpmbuild/SPECS/ca-certificates.spec) Config(fedora-39-x86_64) 0 minutes 19 seconds
INFO: Results and/or logs in: /var/lib/mock/fedora-39-x86_64/result
Finish: run
```


you must always indicate an url in the spec file for sources and patches